### PR TITLE
feat(lib): add OperationWaiter type with customizable timeout and strategies

### DIFF
--- a/lib/operation.go
+++ b/lib/operation.go
@@ -9,33 +9,357 @@ import (
 	"github.com/nirvana-labs/nirvana-go/operations"
 )
 
-// Wait polls the operation status until it's 'done' or times out.
-func Wait(ctx context.Context, client *nirvana.Client, operationID string) error {
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
+const (
+	// DefaultTimeout is the default maximum time to wait for an operation to complete.
+	// Used by NewOperationWaiter() when no custom timeout is specified.
+	DefaultTimeout = 10 * time.Minute
 
-	timeoutDuration := 10 * time.Minute
-	timeout := time.After(timeoutDuration)
+	// DefaultPollInterval is the default interval between operation status checks.
+	// Used by NewOperationWaiter() when no custom polling strategy is specified.
+	DefaultPollInterval = 1 * time.Second
+)
+
+// WaitStrategy defines how polling intervals are calculated for operation waiting.
+// This interface allows for different backoff strategies like fixed intervals,
+// linear backoff, exponential backoff, or custom implementations.
+//
+// Example usage:
+//
+//	strategy := NewLinearBackoffStrategy(1*time.Second, 500*time.Millisecond, 5*time.Second)
+//	waiter := NewOperationWaiter().WithStrategy(strategy)
+type WaitStrategy interface {
+	// NextInterval returns the next polling interval given the current attempt number (0-based).
+	// The attempt parameter starts at 0 for the first retry after the initial poll.
+	NextInterval(attempt int) time.Duration
+	// Reset is called when starting a new wait operation to allow strategies
+	// to reset any internal state if needed.
+	Reset()
+}
+
+// FixedIntervalStrategy implements WaitStrategy with constant polling intervals.
+// This is the simplest strategy that polls at regular, unchanging intervals.
+// It's ideal when you want consistent polling frequency regardless of how long
+// the operation has been running.
+type FixedIntervalStrategy struct {
+	interval time.Duration
+}
+
+// NewFixedIntervalStrategy creates a strategy that polls at fixed intervals.
+// The interval parameter determines how long to wait between each poll attempt.
+//
+// Example:
+//
+//	strategy := NewFixedIntervalStrategy(2 * time.Second)
+//	waiter := NewOperationWaiter().WithStrategy(strategy)
+func NewFixedIntervalStrategy(interval time.Duration) *FixedIntervalStrategy {
+	return &FixedIntervalStrategy{interval: interval}
+}
+
+// NextInterval returns the fixed interval regardless of attempt number.
+// This implements the WaitStrategy interface.
+func (s *FixedIntervalStrategy) NextInterval(attempt int) time.Duration {
+	return s.interval
+}
+
+// Reset is a no-op for fixed interval strategy as there's no state to reset.
+// This implements the WaitStrategy interface.
+func (s *FixedIntervalStrategy) Reset() {}
+
+// LinearBackoffStrategy implements WaitStrategy with linearly increasing intervals.
+// Each successive poll waits longer by a fixed increment, up to a maximum interval.
+// This is useful when you want to gradually reduce polling frequency to avoid
+// overwhelming the service while still getting reasonably quick updates initially.
+//
+// Formula: interval = baseInterval + (attempt * increment), capped at maxInterval
+type LinearBackoffStrategy struct {
+	baseInterval time.Duration // Initial polling interval
+	increment    time.Duration // Amount to increase each attempt
+	maxInterval  time.Duration // Maximum interval to prevent infinite growth
+}
+
+// NewLinearBackoffStrategy creates a strategy with linear backoff.
+// The baseInterval is the starting poll interval, increment is added for each
+// subsequent attempt, and maxInterval caps the maximum wait time.
+//
+// Example - start at 1s, increase by 500ms each attempt, max 5s:
+//
+//	strategy := NewLinearBackoffStrategy(1*time.Second, 500*time.Millisecond, 5*time.Second)
+//	// Attempt 0: 1s, Attempt 1: 1.5s, Attempt 2: 2s, ..., Attempt 8+: 5s
+func NewLinearBackoffStrategy(baseInterval, increment, maxInterval time.Duration) *LinearBackoffStrategy {
+	return &LinearBackoffStrategy{
+		baseInterval: baseInterval,
+		increment:    increment,
+		maxInterval:  maxInterval,
+	}
+}
+
+// NextInterval calculates the next polling interval using linear backoff.
+// Returns baseInterval + (attempt * increment), capped at maxInterval.
+// This implements the WaitStrategy interface.
+func (s *LinearBackoffStrategy) NextInterval(attempt int) time.Duration {
+	interval := s.baseInterval + time.Duration(attempt)*s.increment
+	if interval > s.maxInterval {
+		return s.maxInterval
+	}
+	return interval
+}
+
+// Reset is a no-op for linear backoff strategy as there's no state to reset.
+// This implements the WaitStrategy interface.
+func (s *LinearBackoffStrategy) Reset() {}
+
+// ExponentialBackoffStrategy implements WaitStrategy with exponentially increasing intervals.
+// Each successive poll waits exponentially longer, which is ideal for operations that
+// might take a long time and where you want to quickly back off to avoid overwhelming
+// the service while still eventually checking for completion.
+//
+// Formula: interval = baseInterval * multiplier * attempt, capped at maxInterval
+type ExponentialBackoffStrategy struct {
+	baseInterval time.Duration // Base interval for calculations
+	multiplier   float64       // Exponential growth factor
+	maxInterval  time.Duration // Maximum interval to prevent excessive delays
+}
+
+// NewExponentialBackoffStrategy creates a strategy with exponential backoff.
+// The baseInterval is used in calculations, multiplier determines growth rate,
+// and maxInterval caps the maximum wait time.
+//
+// Example - start calculations with 100ms base, 2x multiplier, max 30s:
+//
+//	strategy := NewExponentialBackoffStrategy(100*time.Millisecond, 2.0, 30*time.Second)
+//	// Attempt 0: 0ms, Attempt 1: 200ms, Attempt 2: 400ms, Attempt 3: 600ms, etc.
+func NewExponentialBackoffStrategy(baseInterval time.Duration, multiplier float64, maxInterval time.Duration) *ExponentialBackoffStrategy {
+	return &ExponentialBackoffStrategy{
+		baseInterval: baseInterval,
+		multiplier:   multiplier,
+		maxInterval:  maxInterval,
+	}
+}
+
+// NextInterval calculates the next polling interval using exponential backoff.
+// Returns baseInterval * multiplier * attempt, capped at maxInterval.
+// This implements the WaitStrategy interface.
+func (s *ExponentialBackoffStrategy) NextInterval(attempt int) time.Duration {
+	interval := time.Duration(float64(s.baseInterval) * s.multiplier*float64(attempt))
+	if interval > s.maxInterval {
+		return s.maxInterval
+	}
+	return interval
+}
+
+// Reset is a no-op for exponential backoff strategy as there's no state to reset.
+// This implements the WaitStrategy interface.
+func (s *ExponentialBackoffStrategy) Reset() {}
+
+// OperationWaiter provides configurable waiting for operations with support for
+// different polling strategies. It allows you to customize timeout duration and
+// polling behavior (fixed intervals, linear backoff, exponential backoff, etc.).
+//
+// Example usage:
+//
+//	// Default: 10-minute timeout with 1-second fixed intervals
+//	waiter := NewOperationWaiter()
+//
+//	// Custom timeout with linear backoff
+//	waiter := NewOperationWaiter().
+//		WithTimeout(5*time.Minute).
+//		WithLinearBackoff(1*time.Second, 500*time.Millisecond, 10*time.Second)
+//
+//	err := waiter.Wait(ctx, client, "operation-id")
+type OperationWaiter struct {
+	timeout  time.Duration // Maximum time to wait for operation completion
+	strategy WaitStrategy  // Polling strategy (fixed, linear, exponential, custom)
+}
+
+// NewOperationWaiter creates a new OperationWaiter with default settings.
+// Default configuration:
+//   - Timeout: 10 minutes (DefaultTimeout)
+//   - Strategy: Fixed 1-second intervals (DefaultPollInterval)
+//
+// The returned waiter can be customized using the With* methods before calling Wait.
+//
+// Example with exponential backoff:
+//
+//	waiter := NewOperationWaiter().
+//		WithTimeout(5*time.Minute).
+//		WithExponentialBackoff(100*time.Millisecond, 2.0, 30*time.Second)
+//	err := waiter.Wait(ctx, client, operationID)
+func NewOperationWaiter() *OperationWaiter {
+	return &OperationWaiter{
+		timeout:  DefaultTimeout,
+		strategy: NewFixedIntervalStrategy(DefaultPollInterval),
+	}
+}
+
+// WithTimeout sets the maximum duration to wait for operation completion.
+// If the operation doesn't complete within this timeout, Wait() will return a timeout error.
+//
+// Example:
+//
+//	waiter := NewOperationWaiter().WithTimeout(5 * time.Minute)
+func (w *OperationWaiter) WithTimeout(timeout time.Duration) *OperationWaiter {
+	w.timeout = timeout
+	return w
+}
+
+// WithPollInterval sets the polling interval using a fixed interval strategy.
+// This is a convenience method that replaces the current strategy with a fixed interval.
+// For more advanced polling strategies, use WithStrategy, WithLinearBackoff, or WithExponentialBackoff.
+//
+// Example:
+//
+//	waiter := NewOperationWaiter().WithPollInterval(2 * time.Second)
+func (w *OperationWaiter) WithPollInterval(interval time.Duration) *OperationWaiter {
+	w.strategy = NewFixedIntervalStrategy(interval)
+	return w
+}
+
+// WithStrategy sets a custom wait strategy that implements the WaitStrategy interface.
+// This allows you to provide your own polling logic or use pre-built strategies.
+//
+// Example:
+//
+//	customStrategy := NewLinearBackoffStrategy(500*time.Millisecond, 100*time.Millisecond, 5*time.Second)
+//	waiter := NewOperationWaiter().WithStrategy(customStrategy)
+func (w *OperationWaiter) WithStrategy(strategy WaitStrategy) *OperationWaiter {
+	w.strategy = strategy
+	return w
+}
+
+// WithLinearBackoff sets a linear backoff strategy where polling intervals increase
+// linearly with each attempt. This is useful when you want to gradually reduce polling
+// frequency while still getting reasonably quick updates.
+//
+// Parameters:
+//   - baseInterval: Starting polling interval
+//   - increment: Amount to increase each attempt
+//   - maxInterval: Maximum interval to prevent infinite growth
+//
+// Example:
+//
+//	waiter := NewOperationWaiter().WithLinearBackoff(1*time.Second, 500*time.Millisecond, 10*time.Second)
+//	// Polls at: 1s, 1.5s, 2s, 2.5s, ..., up to 10s
+func (w *OperationWaiter) WithLinearBackoff(baseInterval, increment, maxInterval time.Duration) *OperationWaiter {
+	w.strategy = NewLinearBackoffStrategy(baseInterval, increment, maxInterval)
+	return w
+}
+
+// WithExponentialBackoff sets an exponential backoff strategy where polling intervals
+// grow exponentially with each attempt. This is ideal for long-running operations where
+// you want to quickly back off to avoid overwhelming the service.
+//
+// Parameters:
+//   - baseInterval: Base interval used in calculations
+//   - multiplier: Growth factor for each attempt
+//   - maxInterval: Maximum interval to prevent excessive delays
+//
+// Example:
+//
+//	waiter := NewOperationWaiter().WithExponentialBackoff(100*time.Millisecond, 2.0, 30*time.Second)
+//	// Polls at: 0ms, 200ms, 400ms, 600ms, ..., up to 30s
+func (w *OperationWaiter) WithExponentialBackoff(baseInterval time.Duration, multiplier float64, maxInterval time.Duration) *OperationWaiter {
+	w.strategy = NewExponentialBackoffStrategy(baseInterval, multiplier, maxInterval)
+	return w
+}
+
+// Wait polls the operation status until it completes, fails, times out, or the context is cancelled.
+// It uses the configured polling strategy to determine wait intervals between status checks.
+//
+// The method will:
+//   - Poll the operation status at intervals determined by the WaitStrategy
+//   - Return nil when the operation status becomes 'done'
+//   - Return an error if the operation fails, times out, or context is cancelled
+//   - Return an error if any API call fails
+//
+// Parameters:
+//   - ctx: Context for cancellation and deadlines
+//   - client: Nirvana client for API calls
+//   - operationID: ID of the operation to wait for
+//
+// Returns an error if the operation fails, times out, is cancelled, or if API calls fail.
+func (w *OperationWaiter) Wait(ctx context.Context, client *nirvana.Client, operationID string) error {
+	w.strategy.Reset()
+	timeoutChan := time.After(w.timeout)
+	
+	attempt := 0
+	var timer *time.Timer
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-timeoutChan:
+			if timer != nil {
+				timer.Stop()
+			}
+			return errors.New("operation timed out after " + w.timeout.String() + " secs")
+		case <-ctx.Done():
+			if timer != nil {
+				timer.Stop()
+			}
+			return errors.New("context cancelled: " + ctx.Err().Error())
+		default:
+			// Check operation status
 			op, err := client.Operations.Get(ctx, operationID)
 			if err != nil {
+				if timer != nil {
+					timer.Stop()
+				}
 				return errors.New("failed to get operation status: " + err.Error())
 			}
 
 			if op.Status == operations.OperationStatusDone {
+				if timer != nil {
+					timer.Stop()
+				}
 				return nil
 			}
 
 			if op.Status == operations.OperationStatusFailed {
+				if timer != nil {
+					timer.Stop()
+				}
 				return errors.New("operation failed")
 			}
-		case <-timeout:
-			return errors.New("operation timed out after " + timeoutDuration.String() + " secs")
-		case <-ctx.Done():
-			return errors.New("context cancelled: " + ctx.Err().Error())
+
+			// Wait for next poll using strategy
+			interval := w.strategy.NextInterval(attempt)
+			if timer != nil {
+				timer.Stop()
+			}
+			timer = time.NewTimer(interval)
+			
+			select {
+			case <-timer.C:
+				attempt++
+				// Continue to next iteration
+			case <-timeoutChan:
+				timer.Stop()
+				return errors.New("operation timed out after " + w.timeout.String() + " secs")
+			case <-ctx.Done():
+				timer.Stop()
+				return errors.New("context cancelled: " + ctx.Err().Error())
+			}
 		}
 	}
+}
+
+// Wait polls the operation status until it's 'done' or times out.
+// This function uses default settings (10-minute timeout, 1-second fixed polling intervals).
+//
+// Deprecated: Use NewOperationWaiter().Wait() for default behavior, or
+// NewOperationWaiter().WithTimeout(timeout).Wait() for custom timeout, or
+// NewOperationWaiter().WithLinearBackoff(...).Wait() for advanced polling strategies.
+//
+// Example migration:
+//
+//	// Old:
+//	err := Wait(ctx, client, operationID)
+//
+//	// New:
+//	err := NewOperationWaiter().Wait(ctx, client, operationID)
+//
+//	// Or with custom timeout:
+//	err := NewOperationWaiter().WithTimeout(5*time.Minute).Wait(ctx, client, operationID)
+func Wait(ctx context.Context, client *nirvana.Client, operationID string) error {
+	waiter := NewOperationWaiter()
+	return waiter.Wait(ctx, client, operationID)
 }

--- a/lib/operation_test.go
+++ b/lib/operation_test.go
@@ -1,0 +1,267 @@
+package lib_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nirvana-labs/nirvana-go"
+	"github.com/nirvana-labs/nirvana-go/lib"
+	"github.com/nirvana-labs/nirvana-go/operations"
+)
+
+// mockOperationsService implements a mock for testing
+type mockOperationsService struct {
+	getFunc func(ctx context.Context, operationID string) (*operations.Operation, error)
+}
+
+func (m *mockOperationsService) Get(ctx context.Context, operationID string) (*operations.Operation, error) {
+	return m.getFunc(ctx, operationID)
+}
+
+func (m *mockOperationsService) List(ctx context.Context) (interface{}, error) {
+	return nil, nil
+}
+
+func TestNewOperationWaiter(t *testing.T) {
+	waiter := lib.NewOperationWaiter()
+	if waiter == nil {
+		t.Fatal("NewOperationWaiter should return a non-nil waiter")
+	}
+}
+
+func TestOperationWaiter_WithTimeout(t *testing.T) {
+	waiter := lib.NewOperationWaiter()
+	customTimeout := 5 * time.Minute
+	
+	result := waiter.WithTimeout(customTimeout)
+	
+	// Should return the same instance for chaining
+	if result != waiter {
+		t.Error("WithTimeout should return the same instance for method chaining")
+	}
+}
+
+func TestOperationWaiter_WithPollInterval(t *testing.T) {
+	waiter := lib.NewOperationWaiter()
+	customInterval := 2 * time.Second
+	
+	result := waiter.WithPollInterval(customInterval)
+	
+	// Should return the same instance for chaining
+	if result != waiter {
+		t.Error("WithPollInterval should return the same instance for method chaining")
+	}
+}
+
+func TestOperationWaiter_Chaining(t *testing.T) {
+	waiter := lib.NewOperationWaiter().
+		WithTimeout(30 * time.Second).
+		WithPollInterval(500 * time.Millisecond)
+	
+	if waiter == nil {
+		t.Fatal("Method chaining should work and return a valid waiter")
+	}
+}
+
+func TestWait_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+	
+	// Create a mock client that would normally succeed
+	client := &nirvana.Client{}
+	
+	waiter := lib.NewOperationWaiter().WithTimeout(10 * time.Second)
+	err := waiter.Wait(ctx, client, "test-operation")
+	
+	if err == nil {
+		t.Fatal("Wait should return an error when context is cancelled")
+	}
+	
+	if !errors.Is(err, context.Canceled) && !isContextCancelledError(err) {
+		t.Errorf("Expected context cancellation error, got: %v", err)
+	}
+}
+
+func TestWait_Timeout(t *testing.T) {
+	ctx := context.Background()
+	client := &nirvana.Client{}
+	
+	// Use a very short timeout to test timeout behavior
+	waiter := lib.NewOperationWaiter().
+		WithTimeout(1 * time.Millisecond)
+	
+	start := time.Now()
+	err := waiter.Wait(ctx, client, "test-operation")
+	elapsed := time.Since(start)
+	
+	if err == nil {
+		t.Fatal("Wait should return an error")
+	}
+	
+	// Should fail quickly due to either timeout or client error
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("Operation took too long: %v", elapsed)
+	}
+	
+	// The error could be either timeout or client configuration error
+	// Both are acceptable for this test
+	t.Logf("Got expected error: %v", err)
+}
+
+func TestDeprecatedWait_BackwardsCompatibility(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	
+	client := &nirvana.Client{}
+	
+	// Test that the deprecated function still works
+	err := lib.Wait(ctx, client, "test-operation")
+	
+	// Should get some error (timeout or network error)
+	if err == nil {
+		t.Error("Expected an error from deprecated Wait function")
+	}
+}
+
+func TestConstants(t *testing.T) {
+	if lib.DefaultTimeout != 10*time.Minute {
+		t.Errorf("DefaultTimeout should be 10 minutes, got %v", lib.DefaultTimeout)
+	}
+	
+	if lib.DefaultPollInterval != 1*time.Second {
+		t.Errorf("DefaultPollInterval should be 1 second, got %v", lib.DefaultPollInterval)
+	}
+}
+
+func TestFixedIntervalStrategy(t *testing.T) {
+	strategy := lib.NewFixedIntervalStrategy(2 * time.Second)
+	
+	// Should return the same interval regardless of attempt
+	if interval := strategy.NextInterval(0); interval != 2*time.Second {
+		t.Errorf("Expected 2s interval, got %v", interval)
+	}
+	
+	if interval := strategy.NextInterval(5); interval != 2*time.Second {
+		t.Errorf("Expected 2s interval, got %v", interval)
+	}
+}
+
+func TestLinearBackoffStrategy(t *testing.T) {
+	strategy := lib.NewLinearBackoffStrategy(1*time.Second, 500*time.Millisecond, 5*time.Second)
+	
+	tests := []struct {
+		attempt  int
+		expected time.Duration
+	}{
+		{0, 1 * time.Second},                    // base
+		{1, 1500 * time.Millisecond},            // base + 1*increment
+		{2, 2 * time.Second},                    // base + 2*increment
+		{10, 5 * time.Second},                   // capped at max
+	}
+	
+	for _, test := range tests {
+		if interval := strategy.NextInterval(test.attempt); interval != test.expected {
+			t.Errorf("Attempt %d: expected %v, got %v", test.attempt, test.expected, interval)
+		}
+	}
+}
+
+func TestExponentialBackoffStrategy(t *testing.T) {
+	strategy := lib.NewExponentialBackoffStrategy(1*time.Second, 2.0, 8*time.Second)
+	
+	tests := []struct {
+		attempt  int
+		expected time.Duration
+	}{
+		{0, 0 * time.Second},                    // base * multiplier * 0
+		{1, 2 * time.Second},                    // base * multiplier * 1
+		{2, 4 * time.Second},                    // base * multiplier * 2
+		{3, 6 * time.Second},                    // base * multiplier * 3
+		{10, 8 * time.Second},                   // capped at max
+	}
+	
+	for _, test := range tests {
+		if interval := strategy.NextInterval(test.attempt); interval != test.expected {
+			t.Errorf("Attempt %d: expected %v, got %v", test.attempt, test.expected, interval)
+		}
+	}
+}
+
+func TestOperationWaiter_WithStrategy(t *testing.T) {
+	strategy := lib.NewLinearBackoffStrategy(1*time.Second, 500*time.Millisecond, 5*time.Second)
+	waiter := lib.NewOperationWaiter().WithStrategy(strategy)
+	
+	if waiter == nil {
+		t.Fatal("WithStrategy should return a valid waiter")
+	}
+}
+
+func TestOperationWaiter_WithLinearBackoff(t *testing.T) {
+	waiter := lib.NewOperationWaiter().WithLinearBackoff(1*time.Second, 500*time.Millisecond, 5*time.Second)
+	
+	if waiter == nil {
+		t.Fatal("WithLinearBackoff should return a valid waiter")
+	}
+}
+
+func TestOperationWaiter_WithExponentialBackoff(t *testing.T) {
+	waiter := lib.NewOperationWaiter().WithExponentialBackoff(1*time.Second, 2.0, 10*time.Second)
+	
+	if waiter == nil {
+		t.Fatal("WithExponentialBackoff should return a valid waiter")
+	}
+}
+
+func TestOperationWaiter_StrategyChainingCombinations(t *testing.T) {
+	// Test different combinations of strategy configuration
+	tests := []struct {
+		name string
+		waiter func() *lib.OperationWaiter
+	}{
+		{
+			name: "LinearBackoff + Timeout",
+			waiter: func() *lib.OperationWaiter {
+				return lib.NewOperationWaiter().
+					WithTimeout(30*time.Second).
+					WithLinearBackoff(500*time.Millisecond, 200*time.Millisecond, 3*time.Second)
+			},
+		},
+		{
+			name: "ExponentialBackoff + Timeout",
+			waiter: func() *lib.OperationWaiter {
+				return lib.NewOperationWaiter().
+					WithTimeout(1*time.Minute).
+					WithExponentialBackoff(100*time.Millisecond, 1.5, 5*time.Second)
+			},
+		},
+		{
+			name: "Custom Strategy",
+			waiter: func() *lib.OperationWaiter {
+				strategy := lib.NewFixedIntervalStrategy(2 * time.Second)
+				return lib.NewOperationWaiter().
+					WithTimeout(45*time.Second).
+					WithStrategy(strategy)
+			},
+		},
+	}
+	
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			waiter := test.waiter()
+			if waiter == nil {
+				t.Fatalf("Strategy configuration should return a valid waiter")
+			}
+		})
+	}
+}
+
+// Helper functions
+func isContextCancelledError(err error) bool {
+	return err != nil && (errors.Is(err, context.Canceled) || 
+		(err.Error() != "" && (
+			err.Error() == "context cancelled: context canceled" ||
+			err.Error() == "context canceled")))
+}
+


### PR DESCRIPTION
Introduce more flexible `Operation` waiting with `OperationWaiter` with customisable timeout and strategies.