### PR TITLE
chore: remove deprecated lib.Wait for operations

### DIFF
--- a/lib/operation.go
+++ b/lib/operation.go
@@ -140,7 +140,7 @@ func NewExponentialBackoffStrategy(baseInterval time.Duration, multiplier float6
 // Returns baseInterval * multiplier * attempt, capped at maxInterval.
 // This implements the WaitStrategy interface.
 func (s *ExponentialBackoffStrategy) NextInterval(attempt int) time.Duration {
-	interval := time.Duration(float64(s.baseInterval) * s.multiplier*float64(attempt))
+	interval := time.Duration(float64(s.baseInterval) * s.multiplier * float64(attempt))
 	if interval > s.maxInterval {
 		return s.maxInterval
 	}
@@ -280,7 +280,7 @@ func (w *OperationWaiter) WithExponentialBackoff(baseInterval time.Duration, mul
 func (w *OperationWaiter) Wait(ctx context.Context, client *nirvana.Client, operationID string) error {
 	w.strategy.Reset()
 	timeoutChan := time.After(w.timeout)
-	
+
 	attempt := 0
 	var timer *time.Timer
 
@@ -326,7 +326,7 @@ func (w *OperationWaiter) Wait(ctx context.Context, client *nirvana.Client, oper
 				timer.Stop()
 			}
 			timer = time.NewTimer(interval)
-			
+
 			select {
 			case <-timer.C:
 				attempt++
@@ -340,26 +340,4 @@ func (w *OperationWaiter) Wait(ctx context.Context, client *nirvana.Client, oper
 			}
 		}
 	}
-}
-
-// Wait polls the operation status until it's 'done' or times out.
-// This function uses default settings (10-minute timeout, 1-second fixed polling intervals).
-//
-// Deprecated: Use NewOperationWaiter().Wait() for default behavior, or
-// NewOperationWaiter().WithTimeout(timeout).Wait() for custom timeout, or
-// NewOperationWaiter().WithLinearBackoff(...).Wait() for advanced polling strategies.
-//
-// Example migration:
-//
-//	// Old:
-//	err := Wait(ctx, client, operationID)
-//
-//	// New:
-//	err := NewOperationWaiter().Wait(ctx, client, operationID)
-//
-//	// Or with custom timeout:
-//	err := NewOperationWaiter().WithTimeout(5*time.Minute).Wait(ctx, client, operationID)
-func Wait(ctx context.Context, client *nirvana.Client, operationID string) error {
-	waiter := NewOperationWaiter()
-	return waiter.Wait(ctx, client, operationID)
 }

--- a/lib/operation_test.go
+++ b/lib/operation_test.go
@@ -34,9 +34,9 @@ func TestNewOperationWaiter(t *testing.T) {
 func TestOperationWaiter_WithTimeout(t *testing.T) {
 	waiter := lib.NewOperationWaiter()
 	customTimeout := 5 * time.Minute
-	
+
 	result := waiter.WithTimeout(customTimeout)
-	
+
 	// Should return the same instance for chaining
 	if result != waiter {
 		t.Error("WithTimeout should return the same instance for method chaining")
@@ -46,9 +46,9 @@ func TestOperationWaiter_WithTimeout(t *testing.T) {
 func TestOperationWaiter_WithPollInterval(t *testing.T) {
 	waiter := lib.NewOperationWaiter()
 	customInterval := 2 * time.Second
-	
+
 	result := waiter.WithPollInterval(customInterval)
-	
+
 	// Should return the same instance for chaining
 	if result != waiter {
 		t.Error("WithPollInterval should return the same instance for method chaining")
@@ -59,7 +59,7 @@ func TestOperationWaiter_Chaining(t *testing.T) {
 	waiter := lib.NewOperationWaiter().
 		WithTimeout(30 * time.Second).
 		WithPollInterval(500 * time.Millisecond)
-	
+
 	if waiter == nil {
 		t.Fatal("Method chaining should work and return a valid waiter")
 	}
@@ -68,17 +68,17 @@ func TestOperationWaiter_Chaining(t *testing.T) {
 func TestWait_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
-	
+
 	// Create a mock client that would normally succeed
 	client := &nirvana.Client{}
-	
+
 	waiter := lib.NewOperationWaiter().WithTimeout(10 * time.Second)
 	err := waiter.Wait(ctx, client, "test-operation")
-	
+
 	if err == nil {
 		t.Fatal("Wait should return an error when context is cancelled")
 	}
-	
+
 	if !errors.Is(err, context.Canceled) && !isContextCancelledError(err) {
 		t.Errorf("Expected context cancellation error, got: %v", err)
 	}
@@ -87,49 +87,34 @@ func TestWait_ContextCancellation(t *testing.T) {
 func TestWait_Timeout(t *testing.T) {
 	ctx := context.Background()
 	client := &nirvana.Client{}
-	
+
 	// Use a very short timeout to test timeout behavior
 	waiter := lib.NewOperationWaiter().
 		WithTimeout(1 * time.Millisecond)
-	
+
 	start := time.Now()
 	err := waiter.Wait(ctx, client, "test-operation")
 	elapsed := time.Since(start)
-	
+
 	if err == nil {
 		t.Fatal("Wait should return an error")
 	}
-	
+
 	// Should fail quickly due to either timeout or client error
 	if elapsed > 100*time.Millisecond {
 		t.Errorf("Operation took too long: %v", elapsed)
 	}
-	
+
 	// The error could be either timeout or client configuration error
 	// Both are acceptable for this test
 	t.Logf("Got expected error: %v", err)
-}
-
-func TestDeprecatedWait_BackwardsCompatibility(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-	defer cancel()
-	
-	client := &nirvana.Client{}
-	
-	// Test that the deprecated function still works
-	err := lib.Wait(ctx, client, "test-operation")
-	
-	// Should get some error (timeout or network error)
-	if err == nil {
-		t.Error("Expected an error from deprecated Wait function")
-	}
 }
 
 func TestConstants(t *testing.T) {
 	if lib.DefaultTimeout != 10*time.Minute {
 		t.Errorf("DefaultTimeout should be 10 minutes, got %v", lib.DefaultTimeout)
 	}
-	
+
 	if lib.DefaultPollInterval != 1*time.Second {
 		t.Errorf("DefaultPollInterval should be 1 second, got %v", lib.DefaultPollInterval)
 	}
@@ -137,12 +122,12 @@ func TestConstants(t *testing.T) {
 
 func TestFixedIntervalStrategy(t *testing.T) {
 	strategy := lib.NewFixedIntervalStrategy(2 * time.Second)
-	
+
 	// Should return the same interval regardless of attempt
 	if interval := strategy.NextInterval(0); interval != 2*time.Second {
 		t.Errorf("Expected 2s interval, got %v", interval)
 	}
-	
+
 	if interval := strategy.NextInterval(5); interval != 2*time.Second {
 		t.Errorf("Expected 2s interval, got %v", interval)
 	}
@@ -150,17 +135,17 @@ func TestFixedIntervalStrategy(t *testing.T) {
 
 func TestLinearBackoffStrategy(t *testing.T) {
 	strategy := lib.NewLinearBackoffStrategy(1*time.Second, 500*time.Millisecond, 5*time.Second)
-	
+
 	tests := []struct {
 		attempt  int
 		expected time.Duration
 	}{
-		{0, 1 * time.Second},                    // base
-		{1, 1500 * time.Millisecond},            // base + 1*increment
-		{2, 2 * time.Second},                    // base + 2*increment
-		{10, 5 * time.Second},                   // capped at max
+		{0, 1 * time.Second},         // base
+		{1, 1500 * time.Millisecond}, // base + 1*increment
+		{2, 2 * time.Second},         // base + 2*increment
+		{10, 5 * time.Second},        // capped at max
 	}
-	
+
 	for _, test := range tests {
 		if interval := strategy.NextInterval(test.attempt); interval != test.expected {
 			t.Errorf("Attempt %d: expected %v, got %v", test.attempt, test.expected, interval)
@@ -170,18 +155,18 @@ func TestLinearBackoffStrategy(t *testing.T) {
 
 func TestExponentialBackoffStrategy(t *testing.T) {
 	strategy := lib.NewExponentialBackoffStrategy(1*time.Second, 2.0, 8*time.Second)
-	
+
 	tests := []struct {
 		attempt  int
 		expected time.Duration
 	}{
-		{0, 0 * time.Second},                    // base * multiplier * 0
-		{1, 2 * time.Second},                    // base * multiplier * 1
-		{2, 4 * time.Second},                    // base * multiplier * 2
-		{3, 6 * time.Second},                    // base * multiplier * 3
-		{10, 8 * time.Second},                   // capped at max
+		{0, 0 * time.Second},  // base * multiplier * 0
+		{1, 2 * time.Second},  // base * multiplier * 1
+		{2, 4 * time.Second},  // base * multiplier * 2
+		{3, 6 * time.Second},  // base * multiplier * 3
+		{10, 8 * time.Second}, // capped at max
 	}
-	
+
 	for _, test := range tests {
 		if interval := strategy.NextInterval(test.attempt); interval != test.expected {
 			t.Errorf("Attempt %d: expected %v, got %v", test.attempt, test.expected, interval)
@@ -192,7 +177,7 @@ func TestExponentialBackoffStrategy(t *testing.T) {
 func TestOperationWaiter_WithStrategy(t *testing.T) {
 	strategy := lib.NewLinearBackoffStrategy(1*time.Second, 500*time.Millisecond, 5*time.Second)
 	waiter := lib.NewOperationWaiter().WithStrategy(strategy)
-	
+
 	if waiter == nil {
 		t.Fatal("WithStrategy should return a valid waiter")
 	}
@@ -200,7 +185,7 @@ func TestOperationWaiter_WithStrategy(t *testing.T) {
 
 func TestOperationWaiter_WithLinearBackoff(t *testing.T) {
 	waiter := lib.NewOperationWaiter().WithLinearBackoff(1*time.Second, 500*time.Millisecond, 5*time.Second)
-	
+
 	if waiter == nil {
 		t.Fatal("WithLinearBackoff should return a valid waiter")
 	}
@@ -208,7 +193,7 @@ func TestOperationWaiter_WithLinearBackoff(t *testing.T) {
 
 func TestOperationWaiter_WithExponentialBackoff(t *testing.T) {
 	waiter := lib.NewOperationWaiter().WithExponentialBackoff(1*time.Second, 2.0, 10*time.Second)
-	
+
 	if waiter == nil {
 		t.Fatal("WithExponentialBackoff should return a valid waiter")
 	}
@@ -217,7 +202,7 @@ func TestOperationWaiter_WithExponentialBackoff(t *testing.T) {
 func TestOperationWaiter_StrategyChainingCombinations(t *testing.T) {
 	// Test different combinations of strategy configuration
 	tests := []struct {
-		name string
+		name   string
 		waiter func() *lib.OperationWaiter
 	}{
 		{
@@ -241,12 +226,12 @@ func TestOperationWaiter_StrategyChainingCombinations(t *testing.T) {
 			waiter: func() *lib.OperationWaiter {
 				strategy := lib.NewFixedIntervalStrategy(2 * time.Second)
 				return lib.NewOperationWaiter().
-					WithTimeout(45*time.Second).
+					WithTimeout(45 * time.Second).
 					WithStrategy(strategy)
 			},
 		},
 	}
-	
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			waiter := test.waiter()
@@ -259,9 +244,7 @@ func TestOperationWaiter_StrategyChainingCombinations(t *testing.T) {
 
 // Helper functions
 func isContextCancelledError(err error) bool {
-	return err != nil && (errors.Is(err, context.Canceled) || 
-		(err.Error() != "" && (
-			err.Error() == "context cancelled: context canceled" ||
+	return err != nil && (errors.Is(err, context.Canceled) ||
+		(err.Error() != "" && (err.Error() == "context cancelled: context canceled" ||
 			err.Error() == "context canceled")))
 }
-


### PR DESCRIPTION
Remove deprecated `lib.Wait` for operations.